### PR TITLE
Feature: PayoutService#store_(bank)_detail

### DIFF
--- a/lib/adyen/api.rb
+++ b/lib/adyen/api.rb
@@ -2,6 +2,7 @@ require 'adyen'
 require 'adyen/api/simple_soap_client'
 require 'adyen/api/payment_service'
 require 'adyen/api/recurring_service'
+require 'adyen/api/payout_service'
 
 module Adyen
   # The API module contains classes that interact with the Adyen SOAP API.
@@ -30,8 +31,8 @@ module Adyen
   #     config.adyen.default_api_params = { :merchant_account => 'MerchantAccount' }
   #
   # Note that you'll need an Adyen notification PSP reference for some of the calls. Because of
-  # this, store all notifications that Adyen sends to you. Moreover, the responses to these calls 
-  # do *not* tell you whether or not the requested action was successful. For this you will also 
+  # this, store all notifications that Adyen sends to you. Moreover, the responses to these calls
+  # do *not* tell you whether or not the requested action was successful. For this you will also
   # have to check the notification.
   #
   # = Authorising payments
@@ -358,6 +359,49 @@ module Adyen
           :shopper => shopper,
           payment_method => params
         }).store_token
+    end
+
+
+    #  Stores the Bank Details so that recurring payouts can be made in the future
+    #
+    #  @example
+    #  response = Adyen::API.store_bank_detail(
+    #    {
+    #      :email => "user@example.com",
+    #      :reference => "userref1"
+    #    },
+    #    {
+    #      :iban => "NL48RABO0132394782",
+    #      :bic => "RABONL2U",
+    #      :bank_name => 'Rabobank',
+    #      :country_code => 'NL',
+    #      :owner_name => 'Test Shopper'
+    #    }
+    #  )
+    #  response.detail_stored?             # => true
+    #
+    #  Now we can access the stored recurring_detail_reference to future Payouts
+    # 
+    #  response.psp_reference              # => "8814223560182875"
+    #  response.recurring_detail_reference # => "8914234560182875"
+    #  response.result_code                # => "success"
+    #
+    #
+    # @option shopper   [Numeric,String] :reference            The shopper’s reference (ID).
+    # @option shopper   [String]         :email                The shopper’s email address.
+    #
+    # @option bank    [String]         :iban                 The International Bank Account Number
+    # @option bank    [String]         :bic                  Business Identifier Code (SWIFT, Bank Code)
+    # @option bank    [String]         :bank_name            The Bank Name.
+    # @option bank    [String]         :country_code         The two letter Country Code
+    # @option bank    [String]         :owner_name           The name of the Account owner
+    #
+    def store_bank_detail(shopper, bank)
+      params = {
+        :shopper => shopper,
+        :bank    => bank
+      }
+      PayoutService.new(params).store_detail
     end
   end
 end

--- a/lib/adyen/api/payout_service.rb
+++ b/lib/adyen/api/payout_service.rb
@@ -1,0 +1,97 @@
+require 'adyen/api/simple_soap_client'
+require 'adyen/api/templates/payout_service'
+
+module Adyen
+  module API
+    # This is the class that maps actions to Adyen’s Payout SOAP service.
+    #
+    # It’s encouraged to use the shortcut methods on the {API} module.
+    # Henceforth, for extensive documentation you should look at the {API} documentation.
+    #
+    # The most important difference is that you instantiate a {PayoutService} with the parameters
+    # that are needed for the call that you will eventually make.
+    #
+    # @example
+    #  payout = Adyen::API::PayoutService.new({
+    #    :shopper => {
+    #      :email => "user@example.com",
+    #      :reference => "example_user_1"
+    #    },
+    #    :bank => {
+    #      :iban => "NL48RABO0132394782",
+    #      :bic => "RABONL2U",
+    #      :bank_name => 'Rabobank',
+    #      :country_code => 'NL',
+    #      :owner_name => 'Test Shopper'
+    #    }
+    #  })
+    #  response = payout.store_detail
+    #  response.detail_stored? # => true
+    #
+    class PayoutService < SimpleSOAPClient
+      # The Adyen Payout SOAP service endpoint uri.
+      ENDPOINT_URI = 'https://pal-%s.adyen.com/pal/servlet/soap/Payout'
+
+      # @see API.store_detail
+      def store_detail
+        call_webservice_action('storeDetail', store_detail_request_body, StoreDetailResponse)
+      end
+
+      private
+
+      def store_detail_request_body
+        content = bank_partial
+        content << ENABLE_RECURRING_PAYOUT_CONTRACT_PARTIAL
+        payout_request_body(content)
+      end
+
+      def payout_request_body(content)
+        validate_parameters!(:merchant_account)
+        content << shopper_partial
+        LAYOUT % [@params[:merchant_account], content]
+      end
+
+      def bank_partial
+        validate_parameters!(:bank => [:iban, :bic, :bank_name, :country_code, :owner_name])
+        bank  = @params[:bank].values_at(:iban, :bic, :bank_name, :country_code, :owner_name)
+        BANK_PARTIAL % bank
+      end
+
+      def shopper_partial
+        validate_parameters!(:shopper => [:email, :reference])
+        @params[:shopper].map { |k, v| SHOPPER_PARTIALS[k] % v }.join("\n")
+      end
+
+      class StoreDetailResponse < Response
+        class << self
+          # @private
+          attr_accessor :request_received_value
+
+          def base_xpath
+            '//payout:storeDetailResponse/payout:response'
+          end
+        end
+
+        response_attrs :psp_reference, :result_code, :recurring_detail_reference
+
+        # This only returns whether or not the request has been successfully received. Check the
+        # subsequent notification to see if the payment was actually mutated.
+        def success?
+          super && params[:response] == self.class.request_received_value
+        end
+
+        alias_method :detail_stored?, :success?
+
+        def params
+          @params ||= xml_querier.xpath(self.class.base_xpath) do |result|
+            {
+              :psp_reference              => result.text('./payout:pspReference'),
+              :result_code                => result.text('./payout:resultCode'),
+              :recurring_detail_reference => result.text('./payout:recurringDetailReference')
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/adyen/api/templates/payout_service.rb
+++ b/lib/adyen/api/templates/payout_service.rb
@@ -1,0 +1,39 @@
+module Adyen
+  module API
+    class PayoutService < SimpleSOAPClient
+      # @private
+      LAYOUT = <<EOS
+<storeDetail xmlns="http://payout.services.adyen.com">
+  <request>
+    <merchantAccount>%s</merchantAccount>
+    %s
+    </request>
+</storeDetail>
+EOS
+
+      # @private
+      BANK_PARTIAL = <<EOS
+<bank>
+  <iban xmlns="http://payment.services.adyen.com">%s</iban>
+  <bic xmlns="http://payment.services.adyen.com">%s</bic>
+  <bankName xmlns="http://payment.services.adyen.com">%s</bankName>
+  <countryCode xmlns="http://payment.services.adyen.com">%s</countryCode>
+  <ownerName xmlns="http://payment.services.adyen.com">%s</ownerName>
+</bank>
+EOS
+
+      # @private
+      ENABLE_RECURRING_PAYOUT_CONTRACT_PARTIAL = <<EOS
+<recurring>
+  <contract xmlns="http://payment.services.adyen.com">PAYOUT</contract>
+</recurring>
+EOS
+
+      # @private
+      SHOPPER_PARTIALS = {
+        :reference => '<shopperReference>%s</shopperReference>',
+        :email     => '<shopperEmail>%s</shopperEmail>'
+      }
+    end
+  end
+end

--- a/lib/adyen/api/xml_querier.rb
+++ b/lib/adyen/api/xml_querier.rb
@@ -9,6 +9,7 @@ module Adyen
     class XMLQuerier
       # The namespaces used by Adyen.
       NS = {
+        'payout'    => 'http://payout.services.adyen.com',
         'soap'      => 'http://schemas.xmlsoap.org/soap/envelope/',
         'payment'   => 'http://payment.services.adyen.com',
         'recurring' => 'http://recurring.services.adyen.com',
@@ -85,7 +86,7 @@ module Adyen
           data
         elsif data.responds_to?(:body)
           data.body.to_s
-        else 
+        else
           data.to_s
         end
       end

--- a/spec/api/payout_service_spec.rb
+++ b/spec/api/payout_service_spec.rb
@@ -1,0 +1,80 @@
+# encoding: UTF-8
+require 'api/spec_helper'
+
+shared_examples_for "payout requests" do
+  it "includes the merchant account handle" do
+    text('./payout:merchantAccount').should == 'SuperShopper'
+  end
+
+  it "includes the bank details" do
+    xpath('./payout:bank') do |bank|
+      bank.text('./payment:iban').should == 'NL48RABO0132394782'
+      bank.text('./payment:bic').should == 'RABONL2U'
+      bank.text('./payment:bankName').should == 'Rabobank'
+      bank.text('./payment:countryCode').should == 'NL'
+      bank.text('./payment:ownerName').should == 'Test Shopper'
+    end
+  end
+
+  it "includes the shopper’s details" do
+    text('./payout:shopperReference').should == 'user-id'
+    text('./payout:shopperEmail').should == 's.hopper@example.com'
+  end
+end
+
+describe Adyen::API::PayoutService do
+  include APISpecHelper
+
+  before do
+    @params = {
+      :shopper => {
+        :email => 's.hopper@example.com',
+        :reference => 'user-id'
+      },
+      :bank => {
+        :iban => "NL48RABO0132394782",
+        :bic => "RABONL2U",
+        :bank_name => 'Rabobank',
+        :country_code => 'NL',
+        :owner_name => 'Test Shopper'
+      }
+    }
+    @payout = @object = Adyen::API::PayoutService.new(@params)
+  end
+
+  describe_request_body_of :store_detail do
+    it_should_behave_like "payout requests"
+
+    it_should_validate_request_parameters :merchant_account,
+                                          :shopper => [:reference, :email],
+                                          :bank => [:iban, :bic, :bank_name, :country_code, :owner_name]
+
+    it_should_validate_request_param(:shopper) do
+      @payout.params[:shopper] = nil
+    end
+
+    [:reference, :email].each do |attr|
+      it_should_validate_request_param(:shopper) do
+        @payout.params[:shopper][attr] = ''
+      end
+    end
+
+    it "includes the necessary recurring contract info" do
+      text('./payout:recurring/payment:contract').should == 'PAYOUT'
+    end
+  end
+
+  describe_response_from :store_detail, STORE_DETAIL_RESPONSE, 'storeDetail' do
+    it_should_return_params_for_each_xml_backend({
+      :psp_reference => '9913134957760023',
+      :result_code => 'Success',
+      :recurring_detail_reference => '2713134957760046'
+    })
+  end
+
+  private
+
+  def node_for_current_method
+    node_for_current_object_and_method.xpath('//payout:storeDetail/payout:request')
+  end
+end

--- a/spec/api/spec_helper.rb
+++ b/spec/api/spec_helper.rb
@@ -333,7 +333,7 @@ LIST_RESPONSE = <<EOS
           </RecurringDetail>
           <RecurringDetail>
             <card xsi:nil="true"/>
-            <bank xsi:nil="true"/>            
+            <bank xsi:nil="true"/>
             <elv>
               <accountHolderName xmlns="http://payment.services.adyen.com">S. Hopper</accountHolderName>
               <bankAccountNumber xmlns="http://payment.services.adyen.com">1234567890</bankAccountNumber>
@@ -441,6 +441,21 @@ CAPTURE_RESPONSE = <<EOS
         <response xmlns="http://payment.services.adyen.com">%s</response>
       </ns1:captureResult>
     </ns1:captureResponse>
+  </soap:Body>
+</soap:Envelope>
+EOS
+
+STORE_DETAIL_RESPONSE = <<EOS
+<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soap:Body>
+    <ns1:storeDetailResponse xmlns:ns1="http://payout.services.adyen.com">
+      <ns1:response>
+        <pspReference xmlns="http://payout.services.adyen.com">9913134957760023</pspReference>
+        <recurringDetailReference xmlns="http://payout.services.adyen.com">2713134957760046</recurringDetailReference>
+        <resultCode xmlns="http://payout.services.adyen.com">Success</resultCode>
+      </ns1:response>
+    </ns1:storeDetailResponse>
   </soap:Body>
 </soap:Envelope>
 EOS


### PR DESCRIPTION
This PR implements the SOAP adapter required to store (bank) details on Adyen, based on the specification in "Adyen Payout Manual v 2.06".

``` ruby
response = Adyen::API.store_bank_detail(
  {
    :email => "user@example.com",
    :reference => "userref1"
  },
  {
    :iban => "NL48RABO0132394782",
    :bic => "RABONL2U",
    :bank_name => 'Rabobank',
    :country_code => 'NL',
    :owner_name => 'Test Shopper'
  }
)
response.detail_stored?             # => true


response.psp_reference              # => "8814223560182875"
response.recurring_detail_reference # => "8914234560182875"
response.result_code                # => "success"
```

The `SubmitPayout` request is not implemented yet.

The `ListRecurringDetails` can be requested with `Adyen::API.list_recurring_details(shopper_reference)`

For more information see the "Adyen Payout Manual" which can be requested by contacting [Adyen Support](https://support.adyen.com).
