### PR TITLE
Chore: Add #invalid_request? and #fault_message and #error

### DIFF
--- a/spec/api/spec_helper.rb
+++ b/spec/api/spec_helper.rb
@@ -459,3 +459,15 @@ STORE_DETAIL_RESPONSE = <<EOS
   </soap:Body>
 </soap:Envelope>
 EOS
+
+STORE_DETAIL_INVALID_RESPONSE = <<EOS
+<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://common.services.adyen.com">
+  <soap:Body>
+    <soap:Fault>
+      <faultcode>soap:Client</faultcode>
+      <faultstring>%s</faultstring>
+    </soap:Fault>
+  </soap:Body>
+</soap:Envelope>
+EOS


### PR DESCRIPTION
This PR adds some methods to return the errors from the `response` object.

``` ruby
response = Adyen::API.store_bank_detail(
  {
    :email => "user@example.com",
    :reference => "userref1"
  },
  {
    :iban => "XX",
    :bic => "RABONL2U",
    :bank_name => 'Rabobank',
    :country_code => 'NL',
    :owner_name => 'Test Shopper'
  }
)
response.detail_stored?             # => false
response.invalid_request?           # => true
response.fault_message              # => "validation 161 Invalid iban"
response.error                      # => [:iban, 'is not a valid IBAN']
```
